### PR TITLE
TA2022-30 feat: 이미지,레이블 같이있는 커스텀 뷰 구현

### DIFF
--- a/idusHomework.xcodeproj/project.pbxproj
+++ b/idusHomework.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3D273CEE28A918F9001A2115 /* ImageWithLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D273CED28A918F9001A2115 /* ImageWithLabelView.swift */; };
 		3D38F82428A5676000D122CC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D38F82328A5676000D122CC /* AppDelegate.swift */; };
 		3D38F82628A5676000D122CC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D38F82528A5676000D122CC /* SceneDelegate.swift */; };
 		3D38F82D28A5676400D122CC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D38F82C28A5676400D122CC /* Assets.xcassets */; };
@@ -49,6 +50,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3D273CED28A918F9001A2115 /* ImageWithLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageWithLabelView.swift; sourceTree = "<group>"; };
 		3D38F82028A5676000D122CC /* idusHomework.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = idusHomework.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D38F82328A5676000D122CC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3D38F82528A5676000D122CC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +104,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3D273CEF28A92D60001A2115 /* CustomView */ = {
+			isa = PBXGroup;
+			children = (
+				3D273CED28A918F9001A2115 /* ImageWithLabelView.swift */,
+			);
+			path = CustomView;
+			sourceTree = "<group>";
+		};
 		3D38F81728A5676000D122CC = {
 			isa = PBXGroup;
 			children = (
@@ -200,6 +210,7 @@
 				3D38F85F28A591F300D122CC /* Constant.swift */,
 				3D38F86528A6150F00D122CC /* Base */,
 				3D38F85A28A56D9700D122CC /* Extension */,
+				3D273CEF28A92D60001A2115 /* CustomView */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -402,6 +413,7 @@
 				3D38F85C28A56DA500D122CC /* Color.swift in Sources */,
 				3D38F82428A5676000D122CC /* AppDelegate.swift in Sources */,
 				3D38F86928A6588200D122CC /* AppStoreResponse.swift in Sources */,
+				3D273CEE28A918F9001A2115 /* ImageWithLabelView.swift in Sources */,
 				3D38F82628A5676000D122CC /* SceneDelegate.swift in Sources */,
 				3D38F86728A6152000D122CC /* BaseViewController.swift in Sources */,
 				3D38F85E28A5804B00D122CC /* FirstSearchBarView.swift in Sources */,

--- a/idusHomework/Configuration/CustomView/ImageWithLabelView.swift
+++ b/idusHomework/Configuration/CustomView/ImageWithLabelView.swift
@@ -1,0 +1,77 @@
+//
+//  ImageWithLabelView.swift
+//  idusHomework
+//
+//  Created by miori Lee on 2022/08/14.
+//
+
+import UIKit
+
+enum Align {
+    case leading
+    case center
+}
+class ImageWithLabelView: UIView {
+    
+    let textLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "test"
+        lb.textColor = .black
+        lb.font = .systemFont(ofSize: 15, weight: .regular)
+        return lb
+    }()
+    let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = nil
+        iv.layer.cornerRadius = 8
+        iv.contentMode = .scaleAspectFit
+        iv.clipsToBounds = true
+        return iv
+    }()
+    let align: Align
+    
+    init(frame: CGRect = CGRect(), align: Align) {
+        self.align = align
+        super.init(frame: frame)
+        setAttribute()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setAttribute() {
+        self.backgroundColor = nil
+    }
+    private func setLayout() {
+        [textLabel, imageView].forEach {
+            self.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: self.topAnchor, constant: 8),
+            imageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.2),
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
+        ])
+        switch align {
+        case .leading:
+            NSLayoutConstraint.activate([
+                imageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                imageView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 12),
+                
+                textLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 15),
+                textLabel.topAnchor.constraint(equalTo: imageView.topAnchor)
+            ])
+        case .center:
+            NSLayoutConstraint.activate([
+                imageView.topAnchor.constraint(equalTo: self.topAnchor, constant: 4),
+                imageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+                
+                textLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+                textLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 20),
+                textLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -4)
+            ])
+        }
+    }
+}


### PR DESCRIPTION
enum 으로 정렬 방향 받아와서, 재활용하여 사용 가능

예 ) .center 일때
<img width="263" alt="스크린샷 2022-08-14 오후 10 20 15" src="https://user-images.githubusercontent.com/46439995/184538970-9440a229-436a-4c00-9fcd-e66143b4acab.png">
